### PR TITLE
fix: Add namespace prefix to .PROCSTEP.RTIME.CORRECTION in vignette

### DIFF
--- a/vignettes/alignment-parameters.qmd
+++ b/vignettes/alignment-parameters.qmd
@@ -136,7 +136,7 @@ The LamaParama object stores:
 
 ```{r extract_params}
 # Extract LamaParama from process history
-proc_hist <- processHistory(xdata_aligned, type = .PROCSTEP.RTIME.CORRECTION)
+proc_hist <- processHistory(xdata_aligned, type = xcms:::.PROCSTEP.RTIME.CORRECTION)
 lama_result <- proc_hist[[length(proc_hist)]]@param
 
 # Verify it's a LamaParama object


### PR DESCRIPTION
Fixed the vignette error where .PROCSTEP.RTIME.CORRECTION was not found by adding the xcms::: namespace prefix to access the internal XCMS constant. This matches the pattern already used in test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)