### PR TITLE
Refactor plotting functions to use ggplot2 layers

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -291,9 +291,6 @@ setGeneric("ghighlightChromPeaks", function(object,
 #' @param col Color for the chromatogram line (default: "black").
 #' @param lty Line type for chromatogram (default: 1).
 #' @param type Plot type (default: "l" for line).
-#' @param xlab X-axis label (default: "retention time").
-#' @param ylab Y-axis label (default: "intensity").
-#' @param main Plot title (default: NULL).
 #' @param peakType Type of peak annotation: "polygon", "point", "rectangle", or "none"
 #'   (default: "polygon").
 #' @param peakCol Color for peak markers (default: "#00000060").
@@ -349,8 +346,6 @@ setGeneric("gplot", function(x, ...)
 #'   parameters. If missing, the function will try to extract it from the object's
 #'   process history (if correspondence has been performed).
 #' @param col Color for the chromatogram lines in the upper panel (default: "#00000060").
-#' @param xlab X-axis label (default: "retention time").
-#' @param main Plot title (default: NULL).
 #' @param peakType Type of peak annotation in upper panel: "polygon", "point",
 #'   "rectangle", or "none" (default: "polygon").
 #' @param peakCol Color for peak markers (default: "#00000060").
@@ -421,8 +416,6 @@ setGeneric("gplot", function(x, ...)
 setGeneric("gplotChromPeakDensity", function(object,
                                               param,
                                               col = "#00000060",
-                                              xlab = "retention time",
-                                              main = NULL,
                                               peakType = c("polygon", "point", "rectangle", "none"),
                                               peakCol = "#00000060",
                                               peakBg = "#00000020",
@@ -540,12 +533,9 @@ setGeneric("gplotChromatogramsOverlay", function(object,
 #'   Default: numeric() (auto-calculate from data).
 #' @param ylim Numeric vector of length 2 specifying m/z range.
 #'   Default: numeric() (auto-calculate from data).
-#' @param xlab X-axis label (default: "retention time").
-#' @param ylab Y-axis label (default: "m/z").
 #' @param pch Point character for feature markers (default: 4).
 #' @param col Color for feature points and connecting lines (default: "#00000060").
 #' @param type Plot type (default: "o" for overplotted points and lines).
-#' @param main Plot title (default: "Feature groups").
 #' @param featureGroups Character vector of feature group identifiers to plot.
 #'   If empty (default), all feature groups are plotted.
 #' @param ... Additional arguments passed to geom functions.
@@ -610,12 +600,9 @@ setGeneric("gplotChromatogramsOverlay", function(object,
 setGeneric("gplotFeatureGroups", function(x,
                                           xlim = numeric(),
                                           ylim = numeric(),
-                                          xlab = "retention time",
-                                          ylab = "m/z",
                                           pch = 4,
                                           col = "#00000060",
                                           type = "o",
-                                          main = "Feature groups",
                                           featureGroups = character(),
                                           ...)
   standardGeneric("gplotFeatureGroups"))

--- a/R/gplot-LamaParama-methods.R
+++ b/R/gplot-LamaParama-methods.R
@@ -11,8 +11,6 @@ NULL
 #' @param index Integer specifying which retention time map to plot (default: 1).
 #' @param colPoints Color for the matched peak points (default: semi-transparent black).
 #' @param colFit Color for the fitted model line (default: semi-transparent black).
-#' @param xlab X-axis label (default: "Matched Chromatographic peaks").
-#' @param ylab Y-axis label (default: "Lamas").
 #' @param ... Additional parameters (currently unused, for S4 compatibility).
 #'
 #' @return A ggplot object.
@@ -69,9 +67,7 @@ NULL
 setMethod("gplot", "LamaParama",
           function(x, index = 1L,
                    colPoints = "#00000060",
-                   colFit = "#00000080",
-                   xlab = "Matched Chromatographic peaks",
-                   ylab = "Lamas", ...) {
+                   colFit = "#00000080", ...) {
 
   # Get the retention time model using XCMS internal function
   model <- xcms:::.rt_model(method = x@method,
@@ -105,7 +101,7 @@ setMethod("gplot", "LamaParama",
                color = colPoints) +
     geom_line(data = line_data, aes(x = obs, y = ref),
               color = colFit) +
-    labs(x = xlab, y = ylab) +
+    labs(x = "Matched Chromatographic peaks", y = "Lamas") +
     theme_bw()
 
   return(p)

--- a/R/gplot-methods.R
+++ b/R/gplot-methods.R
@@ -65,9 +65,6 @@ NULL
                         col = "black",
                         lty = 1,
                         type = "l",
-                        xlab = "retention time",
-                        ylab = "intensity",
-                        main = NULL,
                         peakType = c("polygon", "point", "rectangle", "none"),
                         peakCol = "#00000060",
                         peakBg = "#00000020",
@@ -91,9 +88,8 @@ NULL
         geom_line(color = col, linetype = lty) +
         theme_bw() +
         labs(
-            x = xlab,
-            y = ylab,
-            title = main
+            x = "retention time",
+            y = "intensity"
         )
 
     # Add peak annotations if present
@@ -148,16 +144,12 @@ setMethod("gplot", "XChromatogram",
                    col = "black",
                    lty = 1,
                    type = "l",
-                   xlab = "retention time",
-                   ylab = "intensity",
-                   main = NULL,
                    peakType = c("polygon", "point", "rectangle", "none"),
                    peakCol = "#00000060",
                    peakBg = "#00000020",
                    peakPch = 1,
                    ...) {
-              .gplot_impl(x, col, lty, type, xlab, ylab, main,
-                         peakType, peakCol, peakBg, peakPch, ...)
+              .gplot_impl(x, col, lty, type, peakType, peakCol, peakBg, peakPch, ...)
           })
 
 #' @rdname gplot
@@ -169,9 +161,6 @@ setMethod("gplot", "XChromatograms",
                    col = "#00000060",
                    lty = 1,
                    type = "l",
-                   xlab = "retention time",
-                   ylab = "intensity",
-                   main = NULL,
                    peakType = c("polygon", "point", "rectangle", "none"),
                    peakCol = "#00000060",
                    peakBg = "#00000020",
@@ -204,9 +193,8 @@ setMethod("gplot", "XChromatograms",
                   geom_line(color = col, linetype = lty) +
                   theme_bw() +
                   labs(
-                      x = xlab,
-                      y = ylab,
-                      title = main
+                      x = "retention time",
+                      y = "intensity"
                   )
 
               # Add peak annotations if present and requested
@@ -300,9 +288,6 @@ setMethod("gplot", "MChromatograms",
                    col = "#00000060",
                    lty = 1,
                    type = "l",
-                   xlab = "retention time",
-                   ylab = "intensity",
-                   main = NULL,
                    peakType = c("polygon", "point", "rectangle", "none"),
                    peakCol = "#00000060",
                    peakBg = "#00000020",
@@ -311,8 +296,7 @@ setMethod("gplot", "MChromatograms",
               # MChromatograms can be handled the same way as XChromatograms
               # Convert to XChromatograms if it has peaks, otherwise treat as regular MChromatograms
               if (is(x, "XChromatograms")) {
-                  gplot(x, col = col, lty = lty, type = type, xlab = xlab,
-                       ylab = ylab, main = main, peakType = peakType,
+                  gplot(x, col = col, lty = lty, type = type, peakType = peakType,
                        peakCol = peakCol, peakBg = peakBg, peakPch = peakPch, ...)
               } else {
                   # Regular MChromatograms - plot as overlaid lines
@@ -340,9 +324,8 @@ setMethod("gplot", "MChromatograms",
                       geom_line(color = col, linetype = lty) +
                       theme_bw() +
                       labs(
-                          x = xlab,
-                          y = ylab,
-                          title = main
+                          x = "retention time",
+                          y = "intensity"
                       )
 
                   return(p)

--- a/R/gplotChromPeakDensity-methods.R
+++ b/R/gplotChromPeakDensity-methods.R
@@ -86,8 +86,6 @@ NULL
 .gplotChromPeakDensity_impl <- function(object,
                                          param,
                                          col = "#00000060",
-                                         xlab = "retention time",
-                                         main = NULL,
                                          peakType = c("polygon", "point", "rectangle", "none"),
                                          peakCol = "#00000060",
                                          peakBg = "#00000020",
@@ -132,7 +130,7 @@ NULL
     xl <- range(lapply(object, function(z) range(xcms::rtime(z))))
 
     # Create upper panel: chromatogram plot
-    p_upper <- gplot(object, col = col, xlab = "", main = main,
+    p_upper <- gplot(object, col = col,
                      peakType = peakType, peakCol = peakCol,
                      peakBg = peakBg, peakPch = peakPch, ...) +
         theme(axis.title.x = element_blank(),
@@ -213,7 +211,7 @@ NULL
             breaks = ypos,
             labels = seq(from = min_max_smple[1], to = min_max_smple[2])
         ) +
-        labs(x = xlab, y = "sample") +
+        labs(x = "retention time", y = "sample") +
         theme_bw() +
         xlim(xl)
 
@@ -227,13 +225,13 @@ NULL
 #' @rdname gplotChromPeakDensity
 #' @export
 setMethod("gplotChromPeakDensity", "XChromatograms",
-          function(object, param, col = "#00000060", xlab = "retention time",
-                   main = NULL, peakType = c("polygon", "point", "rectangle", "none"),
+          function(object, param, col = "#00000060",
+                   peakType = c("polygon", "point", "rectangle", "none"),
                    peakCol = "#00000060", peakBg = "#00000020", peakPch = 1,
                    simulate = TRUE, ...) {
 
               .gplotChromPeakDensity_impl(object = object, param = param,
-                                          col = col, xlab = xlab, main = main,
+                                          col = col,
                                           peakType = peakType, peakCol = peakCol,
                                           peakBg = peakBg, peakPch = peakPch,
                                           simulate = simulate, ...)
@@ -242,15 +240,15 @@ setMethod("gplotChromPeakDensity", "XChromatograms",
 #' @rdname gplotChromPeakDensity
 #' @export
 setMethod("gplotChromPeakDensity", "MChromatograms",
-          function(object, param, col = "#00000060", xlab = "retention time",
-                   main = NULL, peakType = c("polygon", "point", "rectangle", "none"),
+          function(object, param, col = "#00000060",
+                   peakType = c("polygon", "point", "rectangle", "none"),
                    peakCol = "#00000060", peakBg = "#00000020", peakPch = 1,
                    simulate = TRUE, ...) {
 
               # Convert MChromatograms to XChromatograms if needed
               # MChromatograms should work the same way as XChromatograms
               .gplotChromPeakDensity_impl(object = object, param = param,
-                                          col = col, xlab = xlab, main = main,
+                                          col = col,
                                           peakType = peakType, peakCol = peakCol,
                                           peakBg = peakBg, peakPch = peakPch,
                                           simulate = simulate, ...)

--- a/R/gplotFeatureGroups-methods.R
+++ b/R/gplotFeatureGroups-methods.R
@@ -14,12 +14,9 @@ utils::globalVariables(c("Retention Time", "m/z", "group", "feature_group"))
 .gplotFeatureGroups_impl <- function(x,
                                      xlim = numeric(),
                                      ylim = numeric(),
-                                     xlab = "retention time",
-                                     ylab = "m/z",
                                      pch = 4,
                                      col = "#00000060",
                                      type = "o",
-                                     main = "Feature groups",
                                      featureGroups = character(),
                                      ...) {
 
@@ -108,7 +105,7 @@ utils::globalVariables(c("Retention Time", "m/z", "group", "feature_group"))
 
     p <- p +
         theme_bw() +
-        labs(x = xlab, y = ylab, title = main) +
+        labs(x = "retention time", y = "m/z", title = "Feature groups") +
         coord_cartesian(xlim = xlim, ylim = ylim)
 
     return(p)
@@ -118,22 +115,18 @@ utils::globalVariables(c("Retention Time", "m/z", "group", "feature_group"))
 #' @export
 setMethod("gplotFeatureGroups", "XCMSnExp",
           function(x, xlim = numeric(), ylim = numeric(),
-                   xlab = "retention time", ylab = "m/z",
                    pch = 4, col = "#00000060", type = "o",
-                   main = "Feature groups", featureGroups = character(),
+                   featureGroups = character(),
                    ...) {
-              .gplotFeatureGroups_impl(x, xlim, ylim, xlab, ylab,
-                                      pch, col, type, main, featureGroups, ...)
+              .gplotFeatureGroups_impl(x, xlim, ylim, pch, col, type, featureGroups, ...)
           })
 
 #' @rdname gplotFeatureGroups
 #' @export
 setMethod("gplotFeatureGroups", "XcmsExperiment",
           function(x, xlim = numeric(), ylim = numeric(),
-                   xlab = "retention time", ylab = "m/z",
                    pch = 4, col = "#00000060", type = "o",
-                   main = "Feature groups", featureGroups = character(),
+                   featureGroups = character(),
                    ...) {
-              .gplotFeatureGroups_impl(x, xlim, ylim, xlab, ylab,
-                                      pch, col, type, main, featureGroups, ...)
+              .gplotFeatureGroups_impl(x, xlim, ylim, pch, col, type, featureGroups, ...)
           })

--- a/tests/testthat/test-gplot-LamaParama.R
+++ b/tests/testthat/test-gplot-LamaParama.R
@@ -113,10 +113,10 @@ test_that("gplot LamaParama handles custom labels", {
   if (length(proc_hist) > 0) {
     param <- proc_hist[[length(proc_hist)]]@param
 
-    # Test custom labels
-    p <- gplot(param, index = 1,
-               xlab = "Custom X",
-               ylab = "Custom Y")
+    # Test custom labels - use ggplot2 labs() after plot creation
+    p <- gplot(param, index = 1) +
+         ggplot2::labs(x = "Custom X",
+                       y = "Custom Y")
 
     expect_s3_class(p, "ggplot")
     expect_equal(p$labels$x, "Custom X")

--- a/tests/testthat/test-gplot.R
+++ b/tests/testthat/test-gplot.R
@@ -77,11 +77,11 @@ test_that("gplot handles custom labels and title", {
 
   chr <- xcms::chromatogram(xdata, mz = c(200, 210), rt = c(2500, 3500))
 
-  # Custom labels
-  p <- gplot(chr[1, 1],
-             xlab = "RT (seconds)",
-             ylab = "Signal",
-             main = "Test Chromatogram")
+  # Custom labels - use ggplot2 labs() after plot creation
+  p <- gplot(chr[1, 1]) +
+       ggplot2::labs(x = "RT (seconds)",
+                     y = "Signal",
+                     title = "Test Chromatogram")
   expect_s3_class(p, "ggplot")
 
   # Check labels are set

--- a/tests/testthat/test-gplotFeatureGroups.R
+++ b/tests/testthat/test-gplotFeatureGroups.R
@@ -120,12 +120,12 @@ test_that("gplotFeatureGroups handles custom parameters", {
     p1 <- gplotFeatureGroups(xdata, col = "red")
     expect_s3_class(p1, "ggplot")
 
-    # Test custom axis labels
-    p2 <- gplotFeatureGroups(xdata, xlab = "RT (sec)", ylab = "Mass/Charge")
+    # Test custom axis labels - use ggplot2 labs() after plot creation
+    p2 <- gplotFeatureGroups(xdata) + ggplot2::labs(x = "RT (sec)", y = "Mass/Charge")
     expect_s3_class(p2, "ggplot")
 
-    # Test custom title
-    p3 <- gplotFeatureGroups(xdata, main = "Custom Title")
+    # Test custom title - use ggplot2 labs() after plot creation
+    p3 <- gplotFeatureGroups(xdata) + ggplot2::labs(title = "Custom Title")
     expect_s3_class(p3, "ggplot")
 })
 

--- a/vignettes/05-feature-grouping.qmd
+++ b/vignettes/05-feature-grouping.qmd
@@ -357,6 +357,20 @@ gplotFeatureGroups(xdata, featureGroups = c("FG.0001", "FG.0002", "FG.0003", "FG
 </div>
 </div>
 
+::: {.callout-note}
+## API Differences
+
+Unlike the original XCMS `plotFeatureGroups()`, the ggplot2 version does not have `xlab`, `ylab`, or `main` parameters. Instead, use ggplot2's `labs()` function to customize labels after plot creation:
+
+```r
+# Customize labels with labs()
+gplotFeatureGroups(xdata, featureGroups = c("FG.0001", "FG.0002")) +
+  labs(x = "Retention Time (s)", y = "Mass/Charge", title = "My Custom Title")
+```
+
+This follows ggplot2 conventions and makes the API more consistent with the broader ggplot2 ecosystem.
+:::
+
 # Session Info
 
 ```{r session_info}


### PR DESCRIPTION
Remove main, xlab, and ylab parameters from 5 plotting functions in favor of ggplot2's labs() function for a more idiomatic API:

- gplotFeatureGroups: Remove main, xlab, ylab
- gplot (XChromatogram, XChromatograms, MChromatograms): Remove main, xlab, ylab
- gplot (LamaParama): Remove xlab, ylab
- gplotChromPeakDensity: Remove main, xlab

BREAKING CHANGE: These functions no longer accept main, xlab, or ylab parameters. Users should use + labs() after plot creation instead:

  # Old API (no longer works)
  gplotFeatureGroups(x, xlab = "RT", main = "Title")

  # New API (ggplot2-idiomatic)
  gplotFeatureGroups(x) + labs(x = "RT", title = "Title")

Updated:
- Function implementations to use hardcoded sensible defaults
- Generic definitions in AllGenerics.R
- Roxygen documentation for all affected functions
- Tests to demonstrate new + labs() approach
- Vignettes with API difference callout notes

Functions with complex handling (gplotChromatogramsOverlay, gplot.XcmsExperiment, gplotPrecursorIons) retain their parameters due to special requirements (faceting, conditional labels, metadata defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)