### PR TITLE
Fix missing readMsExperiment function error

### DIFF
--- a/vignettes/01-raw-data-visualization.qmd
+++ b/vignettes/01-raw-data-visualization.qmd
@@ -58,6 +58,7 @@ This vignette covers the **first step** in the XCMS metabolomics workflow: **vis
 ```{r libraries}
 library(xcms)
 library(xcmsVis)
+library(MsExperiment)
 library(ggplot2)
 library(plotly)
 library(patchwork)


### PR DESCRIPTION
The readMsExperiment() function requires the MsExperiment package to be loaded. Added library(MsExperiment) to the libraries chunk to resolve the error when rendering the vignette.

Fixes the error:
Error in `readMsExperiment()`:
! could not find function "readMsExperiment"

🤖 Generated with [Claude Code](https://claude.com/claude-code)