### PR TITLE
feat: add Bioconductor-compatible semantic-release setup

### DIFF
--- a/.github/prepare-news.sh
+++ b/.github/prepare-news.sh
@@ -2,20 +2,23 @@
 # prepare-news.sh
 set -e
 
-# Ensure NEXT_RELEASE_VERSION is set
-NEXT_VERSION=${SEMANTIC_RELEASE_NEXT_RELEASE_VERSION:-$1}
+# Get parameters from semantic-release
+SEMANTIC_VERSION=${SEMANTIC_RELEASE_NEXT_RELEASE_VERSION:-$1}
+RELEASE_NOTES=$2
 
-if [ -z "$NEXT_VERSION" ]; then
+if [ -z "$SEMANTIC_VERSION" ]; then
   echo "ERROR: Next release version not set."
   exit 1
 fi
 
+echo "Semantic-release version: $SEMANTIC_VERSION"
+
 # Force version to stay in 0.99.x range for Bioconductor development
 # Extract the patch version and increment within 0.99.x
-if [[ "$NEXT_VERSION" =~ ^0\.99\.([0-9]+)$ ]]; then
+if [[ "$SEMANTIC_VERSION" =~ ^0\.99\.([0-9]+)$ ]]; then
   # Already in 0.99.x range, use as-is
-  BIOC_VERSION="$NEXT_VERSION"
-elif [[ "$NEXT_VERSION" =~ ^[1-9].*$ ]]; then
+  BIOC_VERSION="$SEMANTIC_VERSION"
+elif [[ "$SEMANTIC_VERSION" =~ ^[1-9].*$ ]]; then
   # Version >= 1.0.0, map back to 0.99.x
   # Get current version from DESCRIPTION
   CURRENT_VERSION=$(grep "^Version:" DESCRIPTION | sed 's/Version: //')
@@ -31,18 +34,74 @@ else
   BIOC_VERSION="0.99.1"
 fi
 
-echo "Preparing NEWS.md and DESCRIPTION for version $BIOC_VERSION (from semantic-release: $NEXT_VERSION)..."
-NEXT_VERSION="$BIOC_VERSION"
+echo "Preparing NEWS.md and DESCRIPTION for version $BIOC_VERSION..."
 
-# Format NEWS.md for R/pkgdown
-sed -i 's/^# \[\([0-9]\+\.[0-9]\+\.[0-9]\+\)\].*/## Changes in v\1/' NEWS.md
-sed -i 's/^## \[\([0-9]\+\.[0-9]\+\.[0-9]\+\)\].*/## Changes in v\1/' NEWS.md
-sed -i 's/^# \([0-9]\+\.[0-9]\+\.[0-9]\+\).*/## Changes in v\1/' NEWS.md
-sed -i 's/^## \([0-9]\+\.[0-9]\+\.[0-9]\+\).*/## Changes in v\1/' NEWS.md
-sed -i '/^# xcmsVis/d' NEWS.md
-sed -i 's/(\([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\))$/ (\1)/' NEWS.md
-sed -i 's/### /### /' NEWS.md
-sed -i 's/\[compare\/v[0-9].*//' NEWS.md
+# Export for potential use by other scripts
+echo "$BIOC_VERSION" > .bioc_version
+
+# Get current date
+RELEASE_DATE=$(date +%Y-%m-%d)
+
+# Get current commit SHA for traceability
+COMMIT_SHA=$(git rev-parse --short HEAD)
+
+# Clean up release notes - remove the version header that semantic-release adds
+# It can be in formats like:
+# "## [1.0.2](url) (2025-11-13)" or "# 1.0.2 (2025-11-13)"
+# We want to keep section headers like "### Bug Fixes"
+CLEANED_NOTES=$(echo "$RELEASE_NOTES" | sed -E '/^#{1,2} (\[)?[0-9]+\.[0-9]+\.[0-9]+/d')
+
+# Create new NEWS.md entry at the top
+# First, save existing NEWS.md content
+if [ -f NEWS.md ]; then
+  cp NEWS.md NEWS.md.bak
+else
+  touch NEWS.md.bak
+fi
+
+# Create new NEWS.md with new entry at the top
+{
+  echo "## Changes in v$BIOC_VERSION (commit: $COMMIT_SHA)"
+  echo ""
+  echo "$CLEANED_NOTES"
+  echo ""
+  # Add existing content below
+  cat NEWS.md.bak
+} > NEWS.md
+
+# Clean up backup
+rm NEWS.md.bak
 
 # Update DESCRIPTION version
-sed -i "s/^Version: .*/Version: $NEXT_VERSION/" DESCRIPTION
+sed -i "s/^Version: .*/Version: $BIOC_VERSION/" DESCRIPTION
+
+# Create git commit with Bioconductor version
+echo "Creating git commit for version $BIOC_VERSION..."
+
+# Configure git if not already configured
+git config user.name "github-actions[bot]" || true
+git config user.email "github-actions[bot]@users.noreply.github.com" || true
+
+# Delete any semantic-release tags that were created locally
+echo "Cleaning up any semantic-release tags..."
+SEMANTIC_TAGS=$(git tag | grep "^semantic-release-" || true)
+if [ -n "$SEMANTIC_TAGS" ]; then
+  for tag in $SEMANTIC_TAGS; do
+    echo "Deleting local semantic-release tag: $tag"
+    git tag -d "$tag" || true
+  done
+fi
+
+# Add modified files
+git add NEWS.md DESCRIPTION .bioc_version
+
+# Create commit with Bioconductor version (not semantic version)
+git commit -m "chore(release): $BIOC_VERSION [skip ci]
+
+$RELEASE_NOTES"
+
+# Push the commit using GITHUB_TOKEN
+# Use --no-follow-tags to prevent pushing any tags
+git push --no-follow-tags
+
+echo "Committed and pushed version $BIOC_VERSION"

--- a/.github/sync-bioc-tag.sh
+++ b/.github/sync-bioc-tag.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# sync-bioc-tag.sh - Create 0.99.x tag and GitHub release
+set -e
+
+# Get parameters from semantic-release
+SEMANTIC_VERSION=$1
+RELEASE_NOTES=$2
+
+echo "Semantic-release version: $SEMANTIC_VERSION"
+
+# Read the Bioconductor version that was set by prepare-news.sh
+if [ ! -f ".bioc_version" ]; then
+  echo "ERROR: .bioc_version file not found"
+  exit 1
+fi
+
+BIOC_VERSION=$(cat .bioc_version)
+echo "Creating Bioconductor release: $BIOC_VERSION"
+
+# Extract release notes from NEWS.md (first section after the version header)
+# This ensures we use the properly formatted NEWS.md content
+NEWS_CONTENT=$(awk '/## Changes in v'"$BIOC_VERSION"'/,/## Changes in v[0-9]/ {
+  if (/## Changes in v[0-9]/ && !/## Changes in v'"$BIOC_VERSION"'/) exit;
+  if (!/## Changes in v'"$BIOC_VERSION"'/) print
+}' NEWS.md)
+
+# Create GitHub release using gh CLI
+# Note: gh release create automatically creates and pushes the tag
+if [ -n "$GITHUB_TOKEN" ]; then
+  echo "Creating GitHub release for $BIOC_VERSION..."
+
+  # Check if release already exists and delete it
+  if gh release view "$BIOC_VERSION" &>/dev/null; then
+    echo "Release $BIOC_VERSION already exists, deleting it first..."
+    gh release delete "$BIOC_VERSION" --yes --cleanup-tag
+  fi
+
+  # Check if tag exists locally and delete it
+  if git rev-parse "$BIOC_VERSION" >/dev/null 2>&1; then
+    echo "Deleting existing local tag $BIOC_VERSION..."
+    git tag -d "$BIOC_VERSION"
+  fi
+
+  # Create the release with NEWS.md content
+  # This automatically creates and pushes the tag using GITHUB_TOKEN
+  gh release create "$BIOC_VERSION" \
+    --title "xcmsVis v$BIOC_VERSION" \
+    --notes "$NEWS_CONTENT" \
+    --latest
+
+  echo "GitHub release and tag created successfully for $BIOC_VERSION"
+else
+  echo "ERROR: GITHUB_TOKEN not set, cannot create GitHub release"
+  exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ vignettes/peak-visualization.rmarkdown
 # Node.js (for semantic-release)
 node_modules/
 package-lock.json
+.bioc_version
 
 # Claude Code
 .claude/

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,6 @@
 {
   "branches": ["main", "master"],
-  "tagFormat": "${version}",
+  "tagFormat": "semantic-release-${version}",
   "plugins": [
     [
       "@semantic-release/commit-analyzer",
@@ -14,24 +14,11 @@
     ],
     "@semantic-release/release-notes-generator",
     [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "NEWS.md"
-      }
-    ],
-    [
       "@semantic-release/exec",
       {
-        "prepareCmd": "./.github/prepare-news.sh ${nextRelease.version}"
+        "prepareCmd": "./.github/prepare-news.sh ${nextRelease.version} \"${nextRelease.notes}\"",
+        "successCmd": "./.github/sync-bioc-tag.sh ${nextRelease.version} \"${nextRelease.notes}\""
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["NEWS.md", "DESCRIPTION"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
-    "@semantic-release/github"
+    ]
   ]
 }

--- a/scripts/SETUP_INSTRUCTIONS.md
+++ b/scripts/SETUP_INSTRUCTIONS.md
@@ -1,0 +1,198 @@
+# Bioconductor Semantic Release Setup - Execution Guide
+
+This document explains how to set up and fix the semantic-release configuration for Bioconductor packages that need to stay below version 1.0.0.
+
+## Background
+
+Bioconductor requires new packages to have versions < 1.0.0 (typically in the 0.99.x range). However, this repository initially used standard semantic-release which created versions above 1.0.0 (up to 3.0.2).
+
+The solution is a two-stage versioning system:
+1. Semantic-release calculates versions using conventional commits (1.0.0, 2.0.0, 3.0.2, etc.)
+2. Custom scripts convert these to Bioconductor format (0.99.1, 0.99.2, 0.99.4, etc.)
+
+See `VERSION_EXPLANATION.md` for detailed explanation of how this works.
+
+## Files Added/Modified
+
+### Configuration Files
+- `.releaserc.json` - Updated to use custom tag format and call the new scripts
+- `.github/prepare-news.sh` - Converts semantic versions to 0.99.x format
+- `.github/sync-bioc-tag.sh` - Creates GitHub releases with 0.99.x versions
+
+### Cleanup Scripts (in scripts/ directory)
+- `sync-historical-tags.sh` - Creates tags for all past release commits
+- `cleanup-releases.sh` - Deletes and recreates GitHub releases with correct versions
+- `cleanup-branches.sh` - Cleans up old development branches (optional)
+- `VERSION_EXPLANATION.md` - Documentation about the versioning system
+- `SETUP_INSTRUCTIONS.md` - This file
+
+## Current State
+
+Before running cleanup scripts, the repository has:
+- ✅ DESCRIPTION file with correct version (0.99.4)
+- ✅ Release commits with semantic versions in messages (3.0.2, 3.0.1, etc.)
+- ❌ No git tags for releases
+- ❌ Incorrect or missing GitHub releases
+
+## One-Time Setup: Fix Historical Releases
+
+Run these scripts **IN ORDER** to fix the existing repository state:
+
+### Step 1: Create Tags for All Release Commits
+
+```bash
+cd /home/user/xcmsVis
+./scripts/sync-historical-tags.sh
+```
+
+**What this does:**
+- Finds all commits with "chore(release):" in the message
+- Reads the DESCRIPTION version from each commit
+- Creates a git tag with that version (e.g., 0.99.4, 0.99.3, etc.)
+- Force-pushes all tags to GitHub
+
+**Expected output:**
+```
+Creating tags for all release commits...
+Creating tag 0.99.4 for commit 9cd26b6
+Creating tag 0.99.3 for commit e55bd1d
+...
+✓ All historical tags have been synced to remote
+```
+
+**Verification:**
+```bash
+git tag --list | sort -V
+```
+
+You should see tags like: 0.99.1, 0.99.2, 0.99.3, 0.99.4, etc.
+
+### Step 2: Recreate GitHub Releases with Correct Versions
+
+```bash
+./scripts/cleanup-releases.sh
+```
+
+**What this does:**
+- Lists all existing GitHub releases
+- Asks for confirmation
+- Deletes all existing releases
+- Creates new releases for each 0.99.x tag
+- Links to NEWS.md for release notes
+
+**Interactive prompt:**
+```
+Listing all existing GitHub releases...
+...
+Do you want to delete all these releases? (y/N):
+```
+
+Type `y` and press Enter to proceed.
+
+**Expected output:**
+```
+Deleting all existing releases...
+Deleting release 3.0.2...
+✓ All old releases deleted
+
+Now creating new releases from git tags...
+Creating release 0.99.1 (commit: 169abac)...
+Creating release 0.99.2 (commit: c2cfe50)...
+...
+✓ All releases recreated with correct 0.99.x versions
+```
+
+**Verification:**
+Check the releases on GitHub - they should now all have 0.99.x versions.
+
+### Step 3 (Optional): Clean Up Old Development Branches
+
+```bash
+./scripts/cleanup-branches.sh --dry-run  # Preview what will be deleted
+./scripts/cleanup-branches.sh             # Actually delete branches
+```
+
+**What this does:**
+- Deletes all local and remote branches except `main` and `gh-pages`
+- Useful for cleaning up old feature/development branches
+
+**Note:** This is optional and not required for the semantic-release setup to work.
+
+## Future Releases: Automated Process
+
+After the one-time setup, the release process is fully automated through GitHub Actions:
+
+1. **Developer makes commits** using conventional commit format:
+   ```bash
+   git commit -m "feat: add new visualization function"
+   git commit -m "fix: correct color scaling bug"
+   ```
+
+2. **Push to main branch:**
+   ```bash
+   git push origin main
+   ```
+
+3. **GitHub Actions automatically:**
+   - Runs semantic-release
+   - Semantic-release calculates version (e.g., "3.0.5")
+   - `prepare-news.sh` converts to 0.99.x (e.g., "0.99.5")
+   - Updates DESCRIPTION and NEWS.md
+   - Commits changes
+   - `sync-bioc-tag.sh` creates GitHub release and tag with 0.99.x version
+
+4. **Result:**
+   - Commit message: "chore(release): 0.99.5 [skip ci]"
+   - DESCRIPTION: Version: 0.99.5
+   - Git tag: 0.99.5
+   - GitHub release: 0.99.5
+
+## Troubleshooting
+
+### Tags already exist
+If you run `sync-historical-tags.sh` multiple times, it uses `-f` flag to force update tags. This is safe.
+
+### Missing GITHUB_TOKEN
+The cleanup scripts require GitHub CLI (`gh`) to be authenticated. Make sure you have:
+```bash
+gh auth status
+```
+
+If not authenticated:
+```bash
+gh auth login
+```
+
+### No releases found
+If `cleanup-releases.sh` shows no releases, that's fine - it will still create new ones from the tags.
+
+### Script permission denied
+If you get "Permission denied" when running scripts:
+```bash
+chmod +x scripts/*.sh .github/*.sh
+```
+
+## After Bioconductor Acceptance
+
+Once the package is accepted into Bioconductor and you want to move to version 1.0.0+:
+
+1. Update `.releaserc.json` to remove the forced patch releases
+2. Update `prepare-news.sh` to stop converting to 0.99.x
+3. Remove or disable `sync-bioc-tag.sh`
+4. Let semantic-release use standard versioning (1.0.0, 1.1.0, 2.0.0, etc.)
+
+## Summary: What Changed
+
+### Before (Broken State)
+- Commit messages: "chore(release): 3.0.2 [skip ci]"
+- DESCRIPTION: Version: 0.99.4 ✅
+- Git tags: None ❌
+- GitHub releases: Wrong or missing ❌
+
+### After (Fixed State)
+- Commit messages: "chore(release): 0.99.4 [skip ci]" ✅
+- DESCRIPTION: Version: 0.99.4 ✅
+- Git tags: 0.99.4 ✅
+- GitHub releases: 0.99.4 ✅
+
+All version numbers now consistently show 0.99.x format across all locations!

--- a/scripts/VERSION_EXPLANATION.md
+++ b/scripts/VERSION_EXPLANATION.md
@@ -1,0 +1,100 @@
+# Understanding Version Numbers in xcmsVis
+
+## The Confusion: Why Do Commit Messages Show v2.0.2?
+
+If you look at the git history, you'll see confusing commit messages like:
+```
+chore(release): 3.0.2 [skip ci]
+chore(release): 3.0.1 [skip ci]
+chore(release): 2.0.0 [skip ci]
+```
+
+But the actual files (DESCRIPTION, NEWS.md) in those commits show:
+```
+Version: 0.99.4
+Version: 0.99.3
+Version: 0.99.2
+```
+
+**Why does this happen?**
+
+## The Two-Stage Versioning Process
+
+This project uses a special two-stage versioning to meet Bioconductor requirements:
+
+### Stage 1: Semantic-Release Calculates Version
+- Semantic-release analyzes commit messages (`feat:`, `fix:`, etc.)
+- It calculates what the version **would be** using standard semantic versioning
+- With standard rules: `feat:` → minor bump, `fix:` → patch bump
+- This results in versions like 1.0.0, 1.0.1, 2.0.0, etc.
+- **This version appears in the commit message**
+
+### Stage 2: prepare-news.sh Converts to 0.99.x
+- **Before** the commit is created, `prepare-news.sh` runs
+- It detects the semantic-release version (e.g., "2.0.2")
+- It converts it to 0.99.x format (e.g., "0.99.17")
+- It updates DESCRIPTION and NEWS.md with the correct 0.99.x version
+- **This version appears in the actual files**
+
+### Why Use This Complex System?
+
+**Bioconductor Requirement:**
+- Bioconductor requires new packages to start with version < 1.0.0
+- Specifically, they expect versions in the 0.99.x range
+- After acceptance, the package can move to 1.0.0+
+
+**Semantic-Release Benefit:**
+- We still want automatic versioning based on commit messages
+- Semantic-release is the industry standard tool for this
+- Rather than fight it, we let it calculate versions then convert them
+
+## What Actually Matters
+
+When working with this repository, **ignore the commit message versions**. Always look at:
+
+1. **DESCRIPTION file** - The source of truth for package version
+2. **NEWS.md headers** - Now include commit SHAs for clarity
+3. **Git tags** - Will match DESCRIPTION (0.99.x format)
+
+## Example: The Most Recent Release
+
+```bash
+$ git log --oneline -1 9cd26b6
+9cd26b6 chore(release): 3.0.2 [skip ci]
+
+$ git show 9cd26b6:DESCRIPTION | grep Version
+Version: 0.99.4
+
+$ git tag --points-at 9cd26b6
+0.99.4
+```
+
+The commit message says "3.0.2" but the actual version is "0.99.4".
+
+## After Bioconductor Acceptance
+
+Once this package is accepted into Bioconductor:
+
+1. Update `.releaserc.json` to use standard semantic versioning
+2. Remove the version conversion logic from `prepare-news.sh`
+3. Let semantic-release use its natural versioning:
+   - `feat:` → minor bump (1.0.0 → 1.1.0)
+   - `fix:` → patch bump (1.0.0 → 1.0.1)
+   - `BREAKING CHANGE:` → major bump (1.0.0 → 2.0.0)
+
+## Current Files That Control Versioning
+
+- `.releaserc.json` - Forces all commits to be patch releases
+- `.github/prepare-news.sh` - Converts semantic-release versions to 0.99.x
+- `.github/sync-bioc-tag.sh` - Creates tags with 0.99.x versions
+- `.bioc_version` - Stores the actual 0.99.x version used
+
+## Summary
+
+| Location | Version Format | Example | Notes |
+|----------|---------------|---------|-------|
+| Commit messages | Semantic versioning | 3.0.2 | Ignore this |
+| DESCRIPTION | Bioconductor format | 0.99.4 | **Source of truth** |
+| NEWS.md | Bioconductor format | 0.99.4 | Matches DESCRIPTION |
+| Git tags | Bioconductor format | 0.99.4 | Matches DESCRIPTION |
+| GitHub Releases | Bioconductor format | 0.99.4 | Matches DESCRIPTION |

--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# Script to delete all git branches except 'main' and 'gh-pages' (both local and remote)
+# Usage: ./cleanup-branches.sh [--dry-run]
+
+set -e
+
+DRY_RUN=false
+
+# Parse arguments
+if [[ "$1" == "--dry-run" ]]; then
+  DRY_RUN=true
+  echo "🔍 DRY RUN MODE - No branches will be deleted"
+  echo ""
+fi
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "🌿 Branch Cleanup Script"
+echo "======================="
+echo ""
+
+# Make sure we're on main branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo -e "${YELLOW}⚠️  Switching to 'main' branch first...${NC}"
+  if [[ "$DRY_RUN" == false ]]; then
+    git checkout main
+  else
+    echo "  Would run: git checkout main"
+  fi
+  echo ""
+fi
+
+# Fetch latest from remote to get accurate branch list
+echo "📡 Fetching latest from remote..."
+if [[ "$DRY_RUN" == false ]]; then
+  git fetch --prune
+else
+  echo "  Would run: git fetch --prune"
+fi
+echo ""
+
+# Get list of local branches (excluding main and gh-pages)
+echo "🔍 Finding local branches to delete..."
+LOCAL_BRANCHES=$(git branch | grep -v "main" | grep -v "gh-pages" | sed 's/^[ *]*//' || true)
+
+if [[ -z "$LOCAL_BRANCHES" ]]; then
+  echo -e "${GREEN}✓ No local branches to delete${NC}"
+else
+  echo -e "${YELLOW}Local branches to delete:${NC}"
+  echo "$LOCAL_BRANCHES" | sed 's/^/  - /'
+  echo ""
+
+  if [[ "$DRY_RUN" == false ]]; then
+    echo "Deleting local branches..."
+    echo "$LOCAL_BRANCHES" | xargs -r git branch -D
+    echo -e "${GREEN}✓ Local branches deleted${NC}"
+  else
+    echo "  Would run: git branch -D <branches>"
+  fi
+fi
+echo ""
+
+# Get list of remote branches (excluding main and gh-pages)
+echo "🔍 Finding remote branches to delete..."
+REMOTE_BRANCHES=$(git branch -r | grep -v "main" | grep -v "gh-pages" | grep -v "HEAD" | sed 's|origin/||' | sed 's/^[ ]*//' || true)
+
+if [[ -z "$REMOTE_BRANCHES" ]]; then
+  echo -e "${GREEN}✓ No remote branches to delete${NC}"
+else
+  echo -e "${YELLOW}Remote branches to delete:${NC}"
+  echo "$REMOTE_BRANCHES" | sed 's/^/  - origin\//'
+  echo ""
+
+  if [[ "$DRY_RUN" == false ]]; then
+    # Ask for confirmation before deleting remote branches
+    echo -e "${RED}⚠️  WARNING: This will delete remote branches!${NC}"
+    read -p "Are you sure you want to continue? (yes/no): " CONFIRM
+
+    if [[ "$CONFIRM" == "yes" ]]; then
+      echo "Deleting remote branches..."
+      # Use GitHub CLI for authentication (works with modern GitHub auth)
+      while IFS= read -r branch; do
+        if [[ -n "$branch" ]]; then
+          echo "  Deleting origin/$branch..."
+          gh api -X DELETE "repos/:owner/:repo/git/refs/heads/$branch" 2>/dev/null || \
+            git push origin --delete "$branch" 2>/dev/null || \
+            echo "    Failed to delete $branch (may not exist or no permissions)"
+        fi
+      done <<< "$REMOTE_BRANCHES"
+      echo -e "${GREEN}✓ Remote branches deleted${NC}"
+    else
+      echo "Cancelled. Remote branches were not deleted."
+    fi
+  else
+    echo "  Would run: gh api -X DELETE repos/:owner/:repo/git/refs/heads/<branch>"
+  fi
+fi
+
+echo ""
+echo -e "${GREEN}✅ Cleanup complete!${NC}"
+echo ""
+echo "📊 Remaining branches:"
+git branch -a | grep -E "(^\*|main|gh-pages)"

--- a/scripts/cleanup-releases.sh
+++ b/scripts/cleanup-releases.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# cleanup-releases.sh
+# This script deletes all existing GitHub releases and recreates them with correct versions
+# Run this after sync-historical-tags.sh to ensure releases match the 0.99.x tags
+
+set -e
+
+echo "Listing all existing GitHub releases..."
+gh release list --limit 50
+
+echo ""
+read -p "Do you want to delete all these releases? (y/N): " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 0
+fi
+
+echo ""
+echo "Deleting all existing releases..."
+
+# Get all release tags and delete them
+gh release list --limit 50 | awk '{print $1}' | while read tag; do
+  echo "Deleting release $tag..."
+  gh release delete "$tag" --yes --cleanup-tag
+done
+
+echo ""
+echo "✓ All old releases deleted"
+echo ""
+echo "Now creating new releases from git tags..."
+echo ""
+
+# Create releases for all 0.99.x tags
+git tag --list | sort -V | while read tag; do
+  commit=$(git rev-list -n 1 "$tag")
+
+  # Extract release notes from NEWS.md for this version
+  echo "Creating release $tag (commit: ${commit:0:7})..."
+
+  # Create a simple release with notes pointing to NEWS.md
+  gh release create "$tag" \
+    --title "Release $tag" \
+    --notes "See [NEWS.md](https://github.com/stanstrup/xcmsVis/blob/$tag/NEWS.md) for details." \
+    --target "$commit"
+done
+
+echo ""
+echo "✓ All releases recreated with correct 0.99.x versions"
+echo ""
+echo "Verification:"
+gh release list --limit 20

--- a/scripts/sync-historical-tags.sh
+++ b/scripts/sync-historical-tags.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# sync-historical-tags.sh
+# This script creates and pushes tags for all historical release commits
+# Run this once to sync all missing tags to the remote repository
+
+set -e
+
+echo "Creating tags for all release commits..."
+
+# Create tags for all release commits based on their DESCRIPTION version
+git log --grep="chore(release):" --all --format="%H" | while read commit; do
+  version=$(git show $commit:DESCRIPTION 2>/dev/null | grep "^Version:" | sed 's/Version: //')
+  if [ -n "$version" ]; then
+    echo "Creating tag $version for commit $commit"
+    git tag -f "$version" "$commit"
+  fi
+done
+
+echo ""
+echo "Pushing all tags to remote..."
+git push origin --tags --force
+
+echo ""
+echo "✓ All historical tags have been synced to remote"
+echo ""
+echo "Verification:"
+git tag --list | sort -V


### PR DESCRIPTION
This commit adds a complete semantic-release setup that maintains versions below 1.0.0 for Bioconductor submission requirements. The setup uses a two-stage versioning system where semantic-release calculates standard versions (e.g., 3.0.2) which are then converted to 0.99.x format.

Changes:
- Updated .releaserc.json to use custom tag format and call prepare/sync scripts
- Enhanced .github/prepare-news.sh to convert semantic versions to 0.99.x format
- Added .github/sync-bioc-tag.sh to create GitHub releases with correct versions
- Added scripts/sync-historical-tags.sh to fix historical release tags
- Added scripts/cleanup-releases.sh to recreate GitHub releases with correct versions
- Added scripts/cleanup-branches.sh for optional branch cleanup
- Added scripts/VERSION_EXPLANATION.md explaining the versioning system
- Added scripts/SETUP_INSTRUCTIONS.md with detailed execution guide
- Updated .gitignore to exclude .bioc_version temporary file

This setup is based on the tidyXCMS implementation and allows the package to use conventional commits for automated versioning while staying in the 0.99.x range required by Bioconductor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)