### PR TITLE
fix: use environment variables for release notes to avoid shell escap…

### DIFF
--- a/.github/prepare-news.sh
+++ b/.github/prepare-news.sh
@@ -2,9 +2,9 @@
 # prepare-news.sh
 set -e
 
-# Get parameters from semantic-release
+# Get parameters from semantic-release (via environment variables)
 SEMANTIC_VERSION=${SEMANTIC_RELEASE_NEXT_RELEASE_VERSION:-$1}
-RELEASE_NOTES=$2
+RELEASE_NOTES=${SEMANTIC_RELEASE_NEXT_RELEASE_NOTES:-$2}
 
 if [ -z "$SEMANTIC_VERSION" ]; then
   echo "ERROR: Next release version not set."

--- a/.github/sync-bioc-tag.sh
+++ b/.github/sync-bioc-tag.sh
@@ -2,9 +2,9 @@
 # sync-bioc-tag.sh - Create 0.99.x tag and GitHub release
 set -e
 
-# Get parameters from semantic-release
-SEMANTIC_VERSION=$1
-RELEASE_NOTES=$2
+# Get parameters from semantic-release (via environment variables)
+SEMANTIC_VERSION=${SEMANTIC_RELEASE_NEXT_RELEASE_VERSION:-$1}
+RELEASE_NOTES=${SEMANTIC_RELEASE_NEXT_RELEASE_NOTES:-$2}
 
 echo "Semantic-release version: $SEMANTIC_VERSION"
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,8 +16,8 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "./.github/prepare-news.sh ${nextRelease.version} \"${nextRelease.notes}\"",
-        "successCmd": "./.github/sync-bioc-tag.sh ${nextRelease.version} \"${nextRelease.notes}\""
+        "prepareCmd": "./.github/prepare-news.sh ${nextRelease.version}",
+        "successCmd": "./.github/sync-bioc-tag.sh ${nextRelease.version}"
       }
     ]
   ]


### PR DESCRIPTION
…ing issues

Changed scripts to read release notes from SEMANTIC_RELEASE_NEXT_RELEASE_NOTES environment variable instead of command-line arguments. This prevents shell syntax errors when notes contain special characters like parentheses.

Updated files:
- .releaserc.json: Removed release notes from command arguments
- .github/prepare-news.sh: Read from env var instead of $2
- .github/sync-bioc-tag.sh: Read from env var instead of $2

This fixes the error: /bin/sh: Syntax error: "(" unexpected

🤖 Generated with [Claude Code](https://claude.com/claude-code)