### PR TITLE
fix: remove .bioc_version from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ vignettes/peak-visualization.rmarkdown
 # Node.js (for semantic-release)
 node_modules/
 package-lock.json
-.bioc_version
 
 # Claude Code
 .claude/


### PR DESCRIPTION
The .bioc_version file needs to be committed as part of the release process to track the actual Bioconductor version used. Removing it from .gitignore allows the prepare-news.sh script to commit it successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)