### PR TITLE
fix: use GITHUB_TOKEN for git push authentication

### DIFF
--- a/.github/prepare-news.sh
+++ b/.github/prepare-news.sh
@@ -102,6 +102,12 @@ $RELEASE_NOTES"
 
 # Push the commit using GITHUB_TOKEN
 # Use --no-follow-tags to prevent pushing any tags
-git push --no-follow-tags
+if [ -n "$GITHUB_TOKEN" ]; then
+  # Configure git to use GITHUB_TOKEN for authentication
+  git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+  git push --no-follow-tags
+else
+  echo "WARNING: GITHUB_TOKEN not set, skipping push (only local commit created)"
+fi
 
 echo "Committed and pushed version $BIOC_VERSION"


### PR DESCRIPTION
Updated prepare-news.sh to configure git remote URL with GITHUB_TOKEN for authentication. This fixes the authentication error when pushing the release commit in GitHub Actions.

Changes:
- Configure git remote to use x-access-token with GITHUB_TOKEN
- Add check for GITHUB_TOKEN existence with fallback message

This fixes: Authentication failed for 'https://github.com/stanstrup/xcmsVis/'

🤖 Generated with [Claude Code](https://claude.com/claude-code)