### PR TITLE
fix: exclude .qmd source files from inst/doc to resolve R CMD check w…

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -29,3 +29,4 @@ tests/testthat/_snap
 vignettes/*_files
 .bioc_version
 scripts/*
+^inst/doc/.*\.qmd$


### PR DESCRIPTION
…arning

R CMD check was failing with 'invalid file names' warning because .qmd source files were being copied to inst/doc/ during package build.

Changes:
- Added ^inst/doc/.*\.qmd$ to .Rbuildignore to exclude .qmd files
- This keeps only .html rendered vignettes in inst/doc/
- Resolves: 'Subdirectory inst/doc contains invalid file names' warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)