### PR TITLE
fix: exclude vignette.rds from inst/doc to resolve source file refere…

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -30,3 +30,4 @@ vignettes/*_files
 .bioc_version
 scripts/*
 ^inst/doc/.*\.qmd$
+^inst/doc/vignette\.rds$


### PR DESCRIPTION
…nce error

R CMD check was failing because vignette.rds references .qmd source files that we excluded from inst/doc in the previous commit.

Changes:
- Added ^inst/doc/vignette\.rds$ to .Rbuildignore
- This prevents the vignette metadata file from looking for excluded sources
- Resolves: 'Source(s) listed in build/vignette.rds but not in package' error

🤖 Generated with [Claude Code](https://claude.com/claude-code)