### PR TITLE
fix: exclude entire inst/doc directory to let R CMD build create it f…

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -29,5 +29,4 @@ tests/testthat/_snap
 vignettes/*_files
 .bioc_version
 scripts/*
-^inst/doc/.*\.qmd$
-^inst/doc/vignette\.rds$
+^inst/doc$


### PR DESCRIPTION
…resh

Changed from selective file exclusion to excluding the entire inst/doc directory. This is the standard R package practice where:
- Vignette sources (.qmd) stay in vignettes/
- R CMD build creates inst/doc/ fresh during build with outputs only
- Prevents 'invalid file names' and 'vignette.rds' mismatch errors

Changes:
- Replaced ^inst/doc/.*\.qmd$ and ^inst/doc/vignette\.rds$ with ^inst/doc$
- This lets R CMD build handle inst/doc creation automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)