### PR TITLE
fix: align .Rbuildignore with quarto package best practices

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,6 +19,9 @@
 ^pkgdown$
 ^\.github$
 ^vignettes/\.quarto$
+^vignettes/.*\.html$
+^doc$
+^Meta$
 ^LICENSE\.md$
 ^xcmsVis.BiocCheck$
 PROJECT_STATUS.md
@@ -29,4 +32,3 @@ tests/testthat/_snap
 vignettes/*_files
 .bioc_version
 scripts/*
-^inst/doc$


### PR DESCRIPTION
Following the pattern used by the quarto R package itself for handling Quarto vignettes properly:

Changes:
- Removed ^inst/doc$ (inst/doc must be included for vignette installation)
- Added ^vignettes/.*\.html$ (exclude HTML outputs from vignettes source dir)
- Added ^doc$ and ^Meta$ (exclude build artifacts at root level)

This matches the quarto-r package configuration and should resolve both:
1. Vignette installation errors (inst/doc is now included)
2. Invalid file name warnings (proper artifact exclusion)

Reference: https://github.com/quarto-dev/quarto-r

🤖 Generated with [Claude Code](https://claude.com/claude-code)