### PR TITLE
fix: add C function registration for DescendMin

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,23 @@
+/*
+ * C function registration for xcmsVis
+ *
+ * Registers C functions to make them available to R via .C()
+ */
+
+#include <R.h>
+#include <Rinternals.h>
+#include <R_ext/Rdynload.h>
+#include "util.h"
+
+/* Declare .C callable functions */
+static const R_CMethodDef CEntries[] = {
+    {"DescendMin", (DL_FUNC) &DescendMin, 5},
+    {NULL, NULL, 0}
+};
+
+/* Register functions when package is loaded */
+void R_init_xcmsVis(DllInfo *dll)
+{
+    R_registerRoutines(dll, CEntries, NULL, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}


### PR DESCRIPTION
Tests were failing with 'DescendMin not available for .C()' because the C function wasn't registered. Modern R packages require explicit registration of C functions.

Changes:
- Added src/init.c with R_init_xcmsVis() registration function
- Registers DescendMin as a .C callable function
- Uses R_useDynamicSymbols(FALSE) for safer symbol lookup

This allows .descendMin() to successfully call the compiled C code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)