### PR TITLE
fix: add useDynLib directive for C function registration

### DIFF
--- a/R/xcms-utils.R
+++ b/R/xcms-utils.R
@@ -7,6 +7,7 @@
 #' @author Original XCMS authors
 #' @keywords internal
 #' @name xcms-utils
+#' @useDynLib xcmsVis, .registration = TRUE
 NULL
 
 #' Find local minima by descending from a peak


### PR DESCRIPTION
Added @useDynLib roxygen directive to ensure the compiled C library is loaded when the package loads. This is required for .C() to find the DescendMin function.

Changes:
- Added @useDynLib xcmsVis, .registration = TRUE to xcms-utils.R
- This will generate useDynLib(xcmsVis, .registration = TRUE) in NAMESPACE
- Matches XCMS package structure for C function registration

After this commit, run roxygen2::roxygenize() to regenerate NAMESPACE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)