### PR TITLE
fix: implement proper LamaParama test pipeline

### DIFF
--- a/tests/testthat/test-gplot-LamaParama.R
+++ b/tests/testthat/test-gplot-LamaParama.R
@@ -15,6 +15,16 @@ get_shared_data <- function() {
   .shared_test_data
 }
 
+# Helper to perform peak grouping (required before LamaParama alignment)
+perform_grouping <- function(xdata, sample_groups) {
+  pdp <- xcms::PeakDensityParam(
+    sampleGroups = sample_groups,
+    minFraction = 0.4,
+    bw = 30
+  )
+  xcms::groupChromPeaks(xdata, param = pdp)
+}
+
 # Helper to get sample groups from xdata object
 get_sample_groups <- function(xdata) {
   if (is(xdata, "XcmsExperiment")) {
@@ -27,17 +37,108 @@ get_sample_groups <- function(xdata) {
 }
 
 # Helper to prepare object with Lama alignment
-# NOTE: LamaParama requires reference dataset with landmarks
-# These tests are currently skipped - see vignette for working example
+# Following the pipeline from step4-retention-time-alignment.qmd vignette
 prepare_lama_alignment <- function(xdata) {
-  skip("LamaParama tests require reference dataset with landmarks")
+  # Load MsFeatures for filtering
+  if (!requireNamespace("MsFeatures", quietly = TRUE)) {
+    skip("MsFeatures package required for LamaParama tests")
+  }
+
+  # Filter to high-quality features present in most samples
+  # Using PercentMissingFilter to keep only features found in at least 80% of samples
+  xdata_filtered <- MsFeatures::filterFeatures(
+    xdata,
+    MsFeatures::PercentMissingFilter(
+      threshold = 20,  # Allow max 20% missing
+      f = if (is(xdata, "XcmsExperiment")) {
+        MsExperiment::sampleData(xdata)$sample_group
+      } else {
+        Biobase::pData(xdata)$sample_group
+      }
+    )
+  )
+
+  # Extract filtered feature definitions to use as landmarks
+  fdef_filtered <- xcms::featureDefinitions(xdata_filtered)
+
+  # Check if we have enough features to create landmarks
+  if (nrow(fdef_filtered) < 3) {
+    skip("Not enough features for LamaParama alignment (need at least 3)")
+  }
+
+  # Create landmark matrix (mz and rt columns) from the subset
+  lamas <- cbind(
+    mz = fdef_filtered$mzmed,
+    rt = fdef_filtered$rtmed
+  )
+
+  # Create LamaParama object
+  lama_param <- xcms::LamaParama(
+    lamas = lamas,
+    method = "loess",
+    span = 0.4
+  )
+
+  # Perform alignment on the original (unfiltered) data using the landmark subset
+  xdata_aligned <- xcms::adjustRtime(xdata, param = lama_param)
+
+  return(list(
+    xdata = xdata_aligned,
+    lama_param = lama_param,
+    n_landmarks = nrow(lamas),
+    n_total_features = nrow(xcms::featureDefinitions(xdata))
+  ))
 }
 
-test_that("gplot works for LamaParama objects", {
+test_that("gplot works for LamaParama objects with XcmsExperiment", {
   shared <- get_shared_data()
 
+  # Group peaks first (required for LamaParama)
+  xdata_grouped <- perform_grouping(shared$xdata_exp, shared$sample_groups)
+
   # Prepare alignment with LamaParama
-  result <- prepare_lama_alignment(shared$xdata_experiment)
+  result <- prepare_lama_alignment(xdata_grouped)
+
+  # Extract the LamaParama object from the result
+  # Note: After adjustRtime, the param is stored in processHistory
+  proc_hist <- xcms::processHistory(result$xdata,
+                                     type = xcms:::.PROCSTEP.RTIME.CORRECTION)
+
+  if (length(proc_hist) > 0) {
+    param <- proc_hist[[length(proc_hist)]]@param
+
+    # Test that param is a LamaParama object
+    expect_s4_class(param, "LamaParama")
+
+    # Test that rtMap is populated
+    expect_true(length(param@rtMap) > 0)
+
+    # Create plot
+    p <- gplot(param, index = 1)
+
+    # Check plot is a ggplot object
+    expect_s3_class(p, "ggplot")
+
+    # Check plot has expected layers
+    expect_true(length(p$layers) >= 2)  # points + line
+
+    # Check for geom_point and geom_line
+    geom_classes <- sapply(p$layers, function(l) class(l$geom)[1])
+    expect_true("GeomPoint" %in% geom_classes)
+    expect_true("GeomLine" %in% geom_classes)
+  } else {
+    skip("No alignment results found in processHistory")
+  }
+})
+
+test_that("gplot works for LamaParama objects with XCMSnExp", {
+  shared <- get_shared_data()
+
+  # Group peaks first (required for LamaParama)
+  xdata_grouped <- perform_grouping(shared$xdata_snexp, shared$sample_groups)
+
+  # Prepare alignment with LamaParama
+  result <- prepare_lama_alignment(xdata_grouped)
 
   # Extract the LamaParama object from the result
   # Note: After adjustRtime, the param is stored in processHistory
@@ -74,7 +175,10 @@ test_that("gplot works for LamaParama objects", {
 test_that("gplot LamaParama handles custom colors", {
   shared <- get_shared_data()
 
-  result <- prepare_lama_alignment(shared$xdata_experiment)
+  # Group peaks first (required for LamaParama)
+  xdata_grouped <- perform_grouping(shared$xdata_exp, shared$sample_groups)
+
+  result <- prepare_lama_alignment(xdata_grouped)
   proc_hist <- xcms::processHistory(result$xdata,
                                      type = xcms:::.PROCSTEP.RTIME.CORRECTION)
 
@@ -95,7 +199,10 @@ test_that("gplot LamaParama handles custom colors", {
 test_that("gplot LamaParama handles custom labels", {
   shared <- get_shared_data()
 
-  result <- prepare_lama_alignment(shared$xdata_experiment)
+  # Group peaks first (required for LamaParama)
+  xdata_grouped <- perform_grouping(shared$xdata_exp, shared$sample_groups)
+
+  result <- prepare_lama_alignment(xdata_grouped)
   proc_hist <- xcms::processHistory(result$xdata,
                                      type = xcms:::.PROCSTEP.RTIME.CORRECTION)
 
@@ -118,7 +225,10 @@ test_that("gplot LamaParama handles custom labels", {
 test_that("gplot LamaParama works with different index values", {
   shared <- get_shared_data()
 
-  result <- prepare_lama_alignment(shared$xdata_experiment)
+  # Group peaks first (required for LamaParama)
+  xdata_grouped <- perform_grouping(shared$xdata_exp, shared$sample_groups)
+
+  result <- prepare_lama_alignment(xdata_grouped)
   proc_hist <- xcms::processHistory(result$xdata,
                                      type = xcms:::.PROCSTEP.RTIME.CORRECTION)
 


### PR DESCRIPTION
- Implement prepare_lama_alignment() following vignette pipeline
- Add perform_grouping() helper for peak grouping before alignment
- Fix variable names (xdata_experiment -> xdata_exp)
- Add test for XCMSnExp objects (now tests both XcmsExperiment and XCMSnExp)
- Use MsFeatures::filterFeatures() with PercentMissingFilter to create landmarks
- All tests now properly group peaks before LamaParama alignment

Follows the step4-retention-time-alignment.qmd vignette pipeline:
1. Group peaks with PeakDensityParam
2. Filter features (80% present) to create landmarks
3. Perform LamaParama alignment with adjustRtime()
4. Extract and test LamaParama object from processHistory

🤖 Generated with [Claude Code](https://claude.com/claude-code)