### PR TITLE
fix: remove namespace prefix from PercentMissingFilter

### DIFF
--- a/tests/testthat/test-gplot-LamaParama.R
+++ b/tests/testthat/test-gplot-LamaParama.R
@@ -47,10 +47,10 @@ prepare_lama_alignment <- function(xdata) {
 
   # Filter to high-quality features present in most samples
   # Using PercentMissingFilter to keep only features found in at least 80% of samples
-  # Note: filterFeatures is a generic S4 method made available by MsFeatures
+  # Note: filterFeatures and PercentMissingFilter are made available by loading MsFeatures
   xdata_filtered <- filterFeatures(
     xdata,
-    MsFeatures::PercentMissingFilter(
+    PercentMissingFilter(
       threshold = 20,  # Allow max 20% missing
       f = if (is(xdata, "XcmsExperiment")) {
         MsExperiment::sampleData(xdata)$sample_group


### PR DESCRIPTION
- Call PercentMissingFilter() directly without MsFeatures:: prefix
- Both filterFeatures and PercentMissingFilter are available from library(MsFeatures)
- These are not exported objects, so must be accessed by loading the library

Fixes error: 'PercentMissingFilter' is not an exported object from 'namespace:MsFeatures'

🤖 Generated with [Claude Code](https://claude.com/claude-code)